### PR TITLE
Updates for 1.0.4

### DIFF
--- a/inc/admin-support.php
+++ b/inc/admin-support.php
@@ -15,4 +15,4 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 <p><?php esc_html_e( 'Though I freely provide this plugin to the WordPress community, consider making a small donation. A few bucks goes a long way towards making improvements','jmitch-tinylytics' ); ?>.</p>
 <p><strong><?php esc_html_e( 'Note:','jmitch-tinylytics' ); ?></strong> <?php esc_html_e( 'Making a donation gets you priority support if you need it','jmitch-tinylytics' ); ?>.</p>
-<p style="margin-top:25px;"><a href="https://ko-fi.com/jimmitchellmedia" target="_blank" class="donate-button"><?php esc_html_e( 'Support Continued Development' ); ?></a></p>
+<p style="margin-top:25px;"><a href="https://donate.stripe.com/9AQ8Ab6Yr8Y67cYdQR" target="_blank" class="donate-button"><?php esc_html_e( 'Support Continued Development' ); ?></a></p>

--- a/jmitch-tinylytics.php
+++ b/jmitch-tinylytics.php
@@ -6,14 +6,14 @@
  * Tags: analytics, ga, google, google analytics, tracking, statistics, stats
  * Author: Jim Mitchell
  * Author URI: https://jimmitchell.org
- * Dontate link: https://ko-fi.com/jimmitchellmedia
+ * Dontate link: https://donate.stripe.com/9AQ8Ab6Yr8Y67cYdQR
  * Requires at least: 4.6
- * Test up to: 6.4
- * Version: 1.0.3
+ * Test up to: 6.4.3
+ * Version: 1.0.4
  * Requires PHP: 5.6.20
  * Text Domain: jmitch-tinylytics
  * Domain Path: /languages
- * License: GPL v2 or later
+ * License: GPL-2.0-or-later
  */
 
 /*
@@ -34,6 +34,8 @@
 */
 
  if (!defined('ABSPATH')) die();
+
+ define( 'TINYLYTICS__VERSION', '1.0.4' );
 
 // Hook functions into WordPress
 add_action('admin_init', 'jmitch_tinylytics_register_settings');
@@ -263,9 +265,9 @@ function jmitch_tinylytics_output_script() {
         
         wp_enqueue_script(
             'jmitch-tinylytics',
-            esc_url($script_url),
+            esc_url_raw( $script_url ),
             array(),
-            NULL,
+            TINYLYTICS__VERSION,
             array(
                 'strategy'  => 'defer',
                 'in_footer' => true
@@ -279,7 +281,7 @@ add_action('wp_footer', 'jmitch_tinylytics_output_script');
 // *** Enqueue user scripts
 function jmitch_tinylytics_user_scripts() {
 	$plugin_url = plugin_dir_url( __FILE__ );
-	wp_enqueue_style( 'style',  $plugin_url . "/css/style.css");
+	wp_enqueue_style( 'style',  $plugin_url . "css/style.css", array(), TINYLYTICS__VERSION, 'all' );
 }
 add_action( 'admin_print_styles', 'jmitch_tinylytics_user_scripts' );
 
@@ -294,10 +296,12 @@ function jmitch_tinylytics_settings_link( $links ) {
 	) );
 	
     $settings_link = '<a href="'. $url .'">' . esc_html__( 'Settings', 'jmitch-tinylytics' ) . '</a>';
+    $donate_link = '<a href="https://donate.stripe.com/9AQ8Ab6Yr8Y67cYdQR" target="_blank">' . esc_html__( 'Donate', 'jmitch-tinylytics' ) . '</a>';
 	
     array_push(
 		$links,
-		$settings_link
+		$settings_link,
+        $donate_link
 	);
 	return $links;
 }

--- a/languages/jmitch-tinylytics.pot
+++ b/languages/jmitch-tinylytics.pot
@@ -14,88 +14,92 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Loco https://localise.biz/"
 
-#: jmitch-tinylytics.php:48
+#: jmitch-tinylytics.php:50
 msgid "General Settings"
 msgstr ""
 
-#: jmitch-tinylytics.php:49
+#: jmitch-tinylytics.php:51
 msgid "Tinylytics Options"
 msgstr ""
 
-#: jmitch-tinylytics.php:51
+#: jmitch-tinylytics.php:53
 msgid "Site ID"
 msgstr ""
 
-#: jmitch-tinylytics.php:52
+#: jmitch-tinylytics.php:54
 msgid "Display hits?"
 msgstr ""
 
-#: jmitch-tinylytics.php:53
+#: jmitch-tinylytics.php:55
 msgid "Link to your public stats?"
 msgstr ""
 
-#: jmitch-tinylytics.php:54
+#: jmitch-tinylytics.php:56
 msgid "Display uptime?"
 msgstr ""
 
-#: jmitch-tinylytics.php:55
+#: jmitch-tinylytics.php:57
 msgid "Display Kudos?"
 msgstr ""
 
-#: jmitch-tinylytics.php:56
+#: jmitch-tinylytics.php:58
 msgid "Kudos label"
 msgstr ""
 
-#: jmitch-tinylytics.php:57
+#: jmitch-tinylytics.php:59
 msgid "Display webring?"
 msgstr ""
 
-#: jmitch-tinylytics.php:58
+#: jmitch-tinylytics.php:60
 msgid "Webring label"
 msgstr ""
 
-#: jmitch-tinylytics.php:59
+#: jmitch-tinylytics.php:61
 msgid "Display webring avatars?"
 msgstr ""
 
-#: jmitch-tinylytics.php:60
+#: jmitch-tinylytics.php:62
 msgid "Display country flags?"
 msgstr ""
 
-#: jmitch-tinylytics.php:96
+#: jmitch-tinylytics.php:98
 msgid "Your unique site id can be found on your"
 msgstr ""
 
-#: jmitch-tinylytics.php:96
+#: jmitch-tinylytics.php:98
 msgid "site page"
 msgstr ""
 
-#: jmitch-tinylytics.php:102
+#: jmitch-tinylytics.php:104
 msgid "These settings enable the various tracking features of"
 msgstr ""
 
-#: jmitch-tinylytics.php:110
+#: jmitch-tinylytics.php:112
 msgid "Enter your Tinylytics unique site id..."
 msgstr ""
 
-#: jmitch-tinylytics.php:118
+#: jmitch-tinylytics.php:120
 msgid "Enter any combination of text or emoji 👋"
 msgstr ""
 
-#: jmitch-tinylytics.php:126
+#: jmitch-tinylytics.php:128
 msgid "Enter any combination of text or emoji 🕸️💍"
 msgstr ""
 
-#: jmitch-tinylytics.php:202
+#: jmitch-tinylytics.php:204
 msgid "Settings Saved"
 msgstr ""
 
-#: jmitch-tinylytics.php:212
+#: jmitch-tinylytics.php:214
 msgid "for"
 msgstr ""
 
-#: jmitch-tinylytics.php:295
+#: jmitch-tinylytics.php:298
 msgid "Settings"
+msgstr ""
+
+#: jmitch-tinylytics.php:299
+msgid "Donate"
 msgstr ""
 
 #: admin-shortcodes.php:14

--- a/readme.txt
+++ b/readme.txt
@@ -6,15 +6,15 @@ Description: Adds your Tinylytics tracking code to your WordPress site.
 Tags: analytics, tracking, statistics, stats, uptime
 Author: Jim Mitchell
 Author URI: https://jimmitchell.org/
-Donate link: https://ko-fi.com/jimmitchellmedia
+Donate link: https://donate.stripe.com/9AQ8Ab6Yr8Y67cYdQR
 Requires at least: 4.6
-Tested up to: 6.4
-Stable tag: 1.0.3
-Version:    1.0.3
+Tested up to: 6.4.3
+Stable tag: 1.0.4
+Version:    1.0.4
 Requires PHP: 5.6.20
 Text Domain: jmitch-tinylytics
 Domain Path: /languages
-License: GPL v2 or later
+License: GPL-2.0-or-later
 Contributors: jimmitchell
 
 Adds Tinylytics tracking code to your WordPress site.
@@ -23,7 +23,7 @@ Adds Tinylytics tracking code to your WordPress site.
 
 == Description ==
 
-This plugin enables Tinylytics for your entire WordPress site. Lightweight and fast with plenty of great features.
+This plugin enables Tinylytics analytics for your entire WordPress site. A Tinylytics account (free or paid) is required to use this plugin. Some Tinylytics premium features will not work in this plugin for free accounts.
 
 
 
@@ -38,7 +38,7 @@ This plugin enables Tinylytics for your entire WordPress site. Lightweight and f
 * Works with or without Gutenberg Block Editor
 * Easy to customize the tracking code
 
-This is a lightweight plugin that inserts the required Tinylytics tracking code. To view your site statistics, visit your Tinylytics account.
+This is a lightweight plugin that inserts a Tinylytics tracking code in the pages of your site. To view your site stats, visit your Tinylytics account.
 
 
 ### Privacy ###
@@ -49,14 +49,14 @@ __Cookies:__ This plugin does not set or rely on any cookies whatsoever.
 
 __Services:__ This plugin connects to the [Tinylytics.app](https://tinylytics.app) platform to record hit data from your site.
 
-Tinylytics is developed and maintained by [Jim Mitchell](https://mastodon.social/@jimmitchell).
+Tinylytics is developed and maintained by [Jim Mitchell](https://social.lol/@jim).
 
 
 ### Support development ###
 
-I develop and maintain this free plugin with love for the WordPress community. To show support, you can [make a donation](https://ko-fi.com/jimmitchellmedia). 
+I develop and maintain this free plugin with love for the WordPress community. To show your support, please [make a donation](https://donate.stripe.com/9AQ8Ab6Yr8Y67cYdQR). 
 
-Links, toots, boosts, tweets and likes also appreciated. Thank you! :)
+Links, toots, boosts, tweets, likes, and kudos are also appreciated. Thank you! :)
 
 
 
@@ -134,6 +134,14 @@ For more information, visit the [Tinylytics Plugin Homepage](https://jimmitchell
 *Thank you to everyone who shares feedback for Tinylytics!*
 
 If you like Tinylytics, please take a moment to [give a 5-star rating](https://wordpress.org/support/plugin/jmitch-tinylytics/reviews/?rate=5#new-post). It helps to keep development and support going strong. Thank you!
+
+**Version 1.0.4 (02-17-2024)**
+
+* Better encoding of Tinylytics Javascript link.
+* Add proper versioning to css and js enqueued resources.
+* Replaced Ko-fi donation page URL with links directly to a Stripe donation page.
+* Updated GPL license reference from "GPL v2 or later" to "GPL-2.0-or-later" so plugin check tool doesn't flag it.
+* Add a Donate link to the plugin listing page.
 
 **Version 1.0.3 (02-11-2024)**
 


### PR DESCRIPTION
- Better encoding of Tinylytics Javascript link.
- Add proper versioning to css and js enqueued resources.
- Replaced Ko-fi donation page URL with links directly to a Stripe donation page.
- Updated GPL license reference from "GPL v2 or later" to "GPL-2.0-or-later" so plugin check tool doesn't flag it.
- Add a Donate link to the plugin listing page.